### PR TITLE
Fix PDF text extraction by installing pdf-parse and improving text cleaning

### DIFF
--- a/service-call-app/app/api/extract-text/route.ts
+++ b/service-call-app/app/api/extract-text/route.ts
@@ -12,7 +12,12 @@ const IMAGE_EXTRACT_PROMPT =
   "Extract ALL text content from this image. Include every product name, price, model number, and any other text visible. Return only the raw text, no formatting or commentary.";
 
 function cleanText(text: string) {
-  return text.replace(/\u0000/g, "").trim().slice(0, MAX_TEXT_LENGTH);
+  return text
+    .replace(/\u0000/g, "")
+    .replace(/--\s*\d+\s+of\s+\d+\s*--/g, "") // strip pdf-parse page separators
+    .replace(/\n{3,}/g, "\n\n") // collapse excessive newlines
+    .trim()
+    .slice(0, MAX_TEXT_LENGTH);
 }
 
 async function extractWithGemini(

--- a/service-call-app/app/price-sheets/page.tsx
+++ b/service-call-app/app/price-sheets/page.tsx
@@ -230,6 +230,12 @@ export default function PriceSheetsPage() {
         body: formData,
       });
 
+      const contentType = res.headers.get("content-type") || "";
+      if (!contentType.includes("application/json")) {
+        console.error("Text extraction API returned non-JSON response:", res.status, contentType);
+        return "";
+      }
+
       const data = await res.json();
 
       if (!res.ok) {


### PR DESCRIPTION
pdf-parse v2 was listed in package.json but never installed, causing the
extract-text API to silently fail on every PDF upload, resulting in empty
textContent in Firestore. Also improved cleanText to strip pdf-parse v2
page separator markers (e.g. "-- 1 of 5 --") and collapse excessive newlines.

https://claude.ai/code/session_01EpANbZTLJ7sMjAZm5e7xvZ