### PR TITLE
Add technician PWA with offline support

### DIFF
--- a/PWA_GUIDE.md
+++ b/PWA_GUIDE.md
@@ -1,0 +1,133 @@
+# Technician PWA — Installation & Usage Guide
+
+The Service Call Dashboard is now an installable **Progressive Web App (PWA)**
+with a mobile-optimized **Technician** view. Techs can install it to their
+home screen, see their open calls at a glance, claim/start/complete calls with
+one tap, and keep working when the network drops (Firestore queues writes
+locally and syncs when you reconnect).
+
+---
+
+## What you get
+
+- `/technician` — mobile-first view for field techs (large tap targets,
+  My Calls / Unassigned / All Open tabs, one-tap Claim → Start → Done flow,
+  tap-to-call caller numbers, floating "New Call" button).
+- Installable app icon on iOS, Android, Chrome, and Edge (launches into
+  `/technician`).
+- Offline mode — service worker caches the app shell; Firestore caches data
+  and queues your status changes until you're back online.
+- Offline banner across the top of the app when the device goes offline.
+- Home-screen shortcuts: **My Calls** and **New Service Call** (long-press the
+  icon on Android / right-click on desktop).
+
+---
+
+## Install the app
+
+### Android (Chrome)
+
+1. Visit the dashboard URL in Chrome.
+2. Sign in with Google.
+3. An **"Install Service Call app"** banner will appear at the bottom — tap
+   **Install**.
+   - Or open the Chrome menu (⋮) → **Install app**.
+4. The icon appears on your home screen; tap it to launch in fullscreen.
+
+### iPhone / iPad (Safari)
+
+Apple doesn't support `beforeinstallprompt`, so installation is manual:
+
+1. Open the dashboard in **Safari** (not Chrome — Safari is required on iOS).
+2. Tap the **Share** button (square with an up arrow).
+3. Scroll down and tap **Add to Home Screen**.
+4. Name it "Service Calls" and tap **Add**.
+
+### Desktop (Chrome / Edge)
+
+1. Visit the dashboard URL.
+2. Click the **install icon** in the address bar (⊕ / computer-with-arrow),
+   or use the banner at the bottom of the screen.
+3. The app launches in its own window and pins to the taskbar / dock.
+
+---
+
+## Using the technician view
+
+First launch:
+
+1. Open the app (it starts on `/technician`).
+2. Sign in with your Google account.
+3. Tap your name from the list ("Who's working today?"). The choice is
+   remembered on this device — tap **Switch user** at the top to change it.
+
+Day-to-day:
+
+- **My Calls** tab → everything currently assigned to you (`takenBy` == your
+  name).
+- **Unassigned** tab → calls no one has picked up yet. Tap **Claim this call**
+  to assign it to yourself and mark it In Progress in one shot.
+- **All Open** tab → every OPEN or IN_PROGRESS call across the business.
+- For calls that are yours:
+  - **Start** (amber) marks it `IN_PROGRESS`.
+  - **Mark done** (green) marks it `DONE` and removes it from the open list.
+- Tap **Call** next to the caller field to dial the customer directly
+  (`tel:` link).
+- Tap **Open full details** to jump to the full edit screen for notes, etc.
+- Tap the floating **+ New Call** button to create a call from the field.
+
+---
+
+## Offline behavior
+
+- A yellow **"Offline — changes will sync when you reconnect"** pill appears
+  at the top whenever the device drops network.
+- Previously visited pages load from cache; new pages fall back to a friendly
+  `/offline` screen.
+- Firestore persistence (`persistentLocalCache`) keeps all the service calls
+  you've already seen available locally, and any Claim / Start / Done updates
+  queue locally and sync automatically as soon as you reconnect — no action
+  needed from the tech.
+
+Notes & caveats:
+- First load requires network (to download the app shell + auth). After that,
+  it works offline until the browser evicts the cache.
+- Sign-in itself requires the network (Google OAuth). Stay signed in to avoid
+  being locked out in a dead zone.
+
+---
+
+## Deployment checklist
+
+These need to be true in production for the PWA to install cleanly:
+
+1. App is served over **HTTPS** (Firebase App Hosting does this automatically).
+2. `/manifest.json` and `/sw.js` are reachable at the site root (they're in
+   `service-call-app/public/`, so Next.js serves them at the root already).
+3. The `NEXT_PUBLIC_FIREBASE_*` env vars are set (same as today).
+4. After deploying a new version, users' service workers will auto-update on
+   next load; nothing else to do.
+
+---
+
+## Files added / changed
+
+**New**
+- `service-call-app/app/technician/page.tsx` — route entry
+- `service-call-app/app/technician/TechnicianView.tsx` — mobile UI
+- `service-call-app/app/offline/page.tsx` — offline fallback
+- `service-call-app/components/PWARegister.tsx` — SW registration, install
+  prompt, offline banner
+- `service-call-app/public/manifest.json` — PWA manifest
+- `service-call-app/public/sw.js` — service worker
+- `service-call-app/public/icons/icon-192.svg`
+- `service-call-app/public/icons/icon-512.svg`
+- `service-call-app/public/icons/icon-maskable.svg`
+
+**Changed**
+- `service-call-app/app/layout.tsx` — manifest link, viewport / theme-color,
+  PWARegister mount
+- `service-call-app/components/NavBar.tsx` — Technician nav link, don't
+  redirect unauthenticated users away from `/technician` or `/offline`
+- `service-call-app/lib/firebase.ts` — enable Firestore IndexedDB persistence
+  on the client

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Welcome to the Service Call Dashboard App! This app is designed to help you mana
 - **Real-time Updates**: Get real-time updates on the status of service calls, ensuring efficient communication and coordination.
 - **Customer Communication**: Communicate with customers directly through the app, keeping them informed every step of the way.
 - **Analytics and Reporting**: Gain valuable insights into service call trends, technician performance, and customer satisfaction.
+- **Installable PWA (Technician View)**: Field techs can install the dashboard to their home screen, work offline, and update call status with one tap. See [`PWA_GUIDE.md`](./PWA_GUIDE.md) for install instructions and usage.
 
 ## Installation
 

--- a/service-call-app/app/layout.tsx
+++ b/service-call-app/app/layout.tsx
@@ -1,7 +1,9 @@
+import type { Metadata, Viewport } from "next";
 import Header from "@/components/NavBar";
 import "./globals.css";
 import { AuthProvider } from "@/components/AuthContext";
 import { Toaster } from "react-hot-toast";
+import PWARegister from "@/components/PWARegister";
 
 import { Inter } from "next/font/google";
 import ChatWithDatabase from "../components/ChatBot";
@@ -10,6 +12,26 @@ const inter = Inter({
   subsets: ["latin"],
   display: "swap",
 });
+
+export const metadata: Metadata = {
+  title: "Service Call Dashboard",
+  description:
+    "Create, assign, and update service calls from the field. Works offline.",
+  manifest: "/manifest.json",
+  applicationName: "Service Call Dashboard",
+  appleWebApp: {
+    capable: true,
+    statusBarStyle: "black-translucent",
+    title: "Service Calls",
+  },
+};
+
+export const viewport: Viewport = {
+  themeColor: "#000000",
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
 
 export default function RootLayout({
   children,
@@ -25,12 +47,14 @@ export default function RootLayout({
           type="image/png"
           sizes="32x32"
         />
+        <link rel="apple-touch-icon" href="/icons/icon-192.svg" />
       </head>
 
       <body>
         <AuthProvider>
           <Header />
           <Toaster position="top-right" />
+          <PWARegister />
           {children}
         </AuthProvider>
       </body>

--- a/service-call-app/app/offline/page.tsx
+++ b/service-call-app/app/offline/page.tsx
@@ -1,0 +1,20 @@
+export const dynamic = "force-static";
+
+export default function OfflinePage() {
+  return (
+    <main className="min-h-screen flex items-center justify-center p-6 bg-gray-50">
+      <div className="max-w-md w-full bg-white rounded-2xl shadow-md p-8 text-center space-y-4">
+        <div className="text-5xl">📡</div>
+        <h1 className="text-2xl font-bold text-gray-900">You&apos;re offline</h1>
+        <p className="text-gray-600">
+          The Service Call Dashboard can&apos;t reach the network right now.
+          Any status changes you already have open will keep working and will sync
+          automatically when you&apos;re back online.
+        </p>
+        <p className="text-sm text-gray-500">
+          Tip: reopen the app — recently visited pages are cached and still load.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/service-call-app/app/technician/TechnicianView.tsx
+++ b/service-call-app/app/technician/TechnicianView.tsx
@@ -1,0 +1,447 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
+import {
+  collection,
+  onSnapshot,
+  orderBy,
+  query,
+  where,
+  doc,
+  updateDoc,
+  Timestamp,
+} from "firebase/firestore";
+import db from "@/lib/firebase";
+import { useAuth } from "@/components/AuthContext";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import toast from "react-hot-toast";
+import {
+  Clock,
+  MapPin,
+  Phone,
+  Wrench,
+  CheckCircle2,
+  PlayCircle,
+  AlertCircle,
+  Plus,
+  Filter,
+} from "lucide-react";
+import { formatDistanceToNow } from "date-fns";
+import { ServiceCall } from "../(definitions)/definitions";
+
+const TECH_NAME_KEY = "technician-name";
+const PREDEFINED_NAMES = [
+  "Kurt",
+  "Chris",
+  "Mike",
+  "Dean",
+  "Damon",
+  "John",
+  "Aaron",
+];
+
+type FilterMode = "mine" | "unassigned" | "all";
+
+export default function TechnicianView() {
+  const { user, loading, signIn } = useAuth();
+  const [techName, setTechName] = useState<string>("");
+  const [filter, setFilter] = useState<FilterMode>("mine");
+  const [calls, setCalls] = useState<ServiceCall[]>([]);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem(TECH_NAME_KEY);
+    if (stored) setTechName(stored);
+  }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    const q = query(
+      collection(db, "ServiceCalls"),
+      where("status", "in", ["OPEN", "IN_PROGRESS"]),
+      orderBy("date", "desc")
+    );
+    const unsub = onSnapshot(
+      q,
+      (snap) => {
+        setCalls(
+          snap.docs.map(
+            (d) =>
+              ({
+                id: d.id,
+                ...d.data(),
+                date: d.data().date ? d.data().date.toDate() : null,
+                updatedAt: d.data().updatedAt
+                  ? d.data().updatedAt.toDate()
+                  : null,
+                createdAt: d.data().createdAt
+                  ? d.data().createdAt.toDate()
+                  : null,
+              }) as ServiceCall
+          )
+        );
+      },
+      (err) => {
+        console.error(err);
+        toast.error("Couldn't load service calls");
+      }
+    );
+    return () => unsub();
+  }, [user]);
+
+  const visibleCalls = useMemo(() => {
+    if (filter === "mine") {
+      if (!techName) return [];
+      return calls.filter((c) => c.takenBy === techName);
+    }
+    if (filter === "unassigned") {
+      return calls.filter(
+        (c) => !c.takenBy || c.takenBy === "Select..." || c.takenBy === ""
+      );
+    }
+    return calls;
+  }, [calls, filter, techName]);
+
+  const handleSaveName = (name: string) => {
+    localStorage.setItem(TECH_NAME_KEY, name);
+    setTechName(name);
+    toast.success(`Signed in as ${name}`);
+  };
+
+  const updateCall = async (
+    id: string,
+    patch: Partial<Pick<ServiceCall, "status" | "takenBy">>,
+    successMsg: string
+  ) => {
+    setBusyId(id);
+    try {
+      await updateDoc(doc(db, "ServiceCalls", id), {
+        ...patch,
+        updatedAt: Timestamp.now(),
+      });
+      toast.success(successMsg);
+    } catch (err) {
+      console.error(err);
+      toast.error("Update failed — will retry when online");
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const claimCall = (id: string) => {
+    if (!techName) {
+      toast.error("Choose your name first");
+      return;
+    }
+    return updateCall(
+      id,
+      { takenBy: techName, status: "IN_PROGRESS" },
+      "Claimed — good luck out there"
+    );
+  };
+
+  const startCall = (id: string) =>
+    updateCall(id, { status: "IN_PROGRESS" }, "Marked in progress");
+
+  const completeCall = (id: string) =>
+    updateCall(id, { status: "DONE" }, "Marked done");
+
+  if (loading) {
+    return (
+      <main className="min-h-[60vh] flex items-center justify-center">
+        <div className="h-10 w-10 rounded-full border-4 border-slate-200 border-t-slate-800 animate-spin" />
+      </main>
+    );
+  }
+
+  if (!user) {
+    return (
+      <main className="min-h-[70vh] flex items-center justify-center p-6">
+        <Card className="max-w-sm w-full">
+          <CardContent className="p-6 space-y-4 text-center">
+            <Wrench className="h-10 w-10 text-slate-700 mx-auto" />
+            <h1 className="text-xl font-bold">Technician Sign-In</h1>
+            <p className="text-sm text-slate-600">
+              Sign in with your Google account to see and update service calls.
+            </p>
+            <Button onClick={signIn} className="w-full">
+              Sign in with Google
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  if (!techName) {
+    return (
+      <main className="min-h-[70vh] flex items-center justify-center p-6">
+        <Card className="max-w-sm w-full">
+          <CardContent className="p-6 space-y-4">
+            <h1 className="text-xl font-bold text-center">
+              Who&apos;s working today?
+            </h1>
+            <p className="text-sm text-slate-600 text-center">
+              Pick your name. We&apos;ll use it when you claim a call.
+            </p>
+            <div className="grid grid-cols-2 gap-2">
+              {PREDEFINED_NAMES.map((name) => (
+                <Button
+                  key={name}
+                  variant="outline"
+                  className="h-12 text-base"
+                  onClick={() => handleSaveName(name)}
+                >
+                  {name}
+                </Button>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </main>
+    );
+  }
+
+  return (
+    <main className="pb-28 px-3 pt-3 max-w-2xl mx-auto">
+      <header className="flex items-center justify-between mb-3">
+        <div>
+          <div className="text-xs text-slate-500">Signed in as</div>
+          <div className="text-lg font-bold">{techName}</div>
+        </div>
+        <button
+          onClick={() => {
+            localStorage.removeItem(TECH_NAME_KEY);
+            setTechName("");
+          }}
+          className="text-xs text-slate-500 underline"
+        >
+          Switch user
+        </button>
+      </header>
+
+      <div
+        role="tablist"
+        className="grid grid-cols-3 rounded-full bg-slate-100 p-1 mb-4"
+      >
+        {(
+          [
+            { id: "mine", label: "My Calls" },
+            { id: "unassigned", label: "Unassigned" },
+            { id: "all", label: "All Open" },
+          ] as const
+        ).map((tab) => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={filter === tab.id}
+            onClick={() => setFilter(tab.id)}
+            className={`rounded-full py-2 text-sm font-medium transition ${
+              filter === tab.id
+                ? "bg-white shadow text-slate-900"
+                : "text-slate-600"
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {visibleCalls.length === 0 ? (
+        <div className="text-center py-14 text-slate-500">
+          <Filter className="h-8 w-8 mx-auto mb-2 text-slate-300" />
+          <p>No calls to show here.</p>
+          {filter === "mine" && (
+            <p className="text-xs mt-2">
+              Check <button className="underline" onClick={() => setFilter("unassigned")}>Unassigned</button> to claim one.
+            </p>
+          )}
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {visibleCalls.map((c) => (
+            <li key={c.id}>
+              <CallCard
+                call={c}
+                busy={busyId === c.id}
+                mine={c.takenBy === techName}
+                onClaim={() => claimCall(c.id!)}
+                onStart={() => startCall(c.id!)}
+                onComplete={() => completeCall(c.id!)}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Link
+        href="/dashboard/create"
+        className="fixed bottom-5 right-5 z-40 flex items-center gap-2 rounded-full bg-slate-900 text-white px-5 py-3 shadow-xl active:scale-95 transition"
+      >
+        <Plus className="h-5 w-5" />
+        <span className="text-sm font-semibold">New Call</span>
+      </Link>
+    </main>
+  );
+}
+
+function CallCard({
+  call,
+  busy,
+  mine,
+  onClaim,
+  onStart,
+  onComplete,
+}: {
+  call: ServiceCall;
+  busy: boolean;
+  mine: boolean;
+  onClaim: () => void;
+  onStart: () => void;
+  onComplete: () => void;
+}) {
+  const assigned =
+    call.takenBy && call.takenBy !== "Select..." && call.takenBy !== "";
+  const inProgress = call.status === "IN_PROGRESS";
+
+  return (
+    <Card
+      className={`${
+        call.overDue ? "border-red-300 bg-red-50" : "border-slate-200"
+      } shadow-sm`}
+    >
+      <CardContent className="p-4 space-y-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="min-w-0">
+            <div className="flex items-center gap-1.5 text-slate-900 font-semibold text-lg truncate">
+              <MapPin className="h-4 w-4 text-slate-500 shrink-0" />
+              <span className="truncate">{call.location || "Unknown"}</span>
+            </div>
+            <div className="flex items-center gap-1.5 text-xs text-slate-500 mt-0.5">
+              <Clock className="h-3 w-3" />
+              {call.date
+                ? formatDistanceToNow(call.date, { addSuffix: true })
+                : "No date"}
+              {call.overDue && (
+                <span className="ml-1 inline-flex items-center gap-0.5 text-red-700 font-medium">
+                  <AlertCircle className="h-3 w-3" />
+                  Overdue
+                </span>
+              )}
+            </div>
+          </div>
+          <StatusBadge status={call.status} />
+        </div>
+
+        <div className="text-sm text-slate-800">
+          <span className="font-medium">Problem:</span>{" "}
+          {call.reportedProblem || "Not specified"}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 text-xs text-slate-600">
+          <div>
+            <span className="font-medium text-slate-700">Machine:</span>{" "}
+            {call.machine || "—"}
+          </div>
+          <div>
+            <span className="font-medium text-slate-700">Caller:</span>{" "}
+            {call.whoCalled || "—"}
+          </div>
+        </div>
+
+        {call.notes && (
+          <div className="text-xs bg-slate-50 rounded-md p-2 text-slate-700 border border-slate-100">
+            {call.notes}
+          </div>
+        )}
+
+        <div className="flex items-center justify-between text-xs pt-1">
+          <div className="text-slate-500">
+            {assigned ? (
+              <>
+                Assigned to <span className="font-medium">{call.takenBy}</span>
+              </>
+            ) : (
+              <span className="text-amber-700 font-medium">Unassigned</span>
+            )}
+          </div>
+          {call.whoCalled && (
+            <a
+              href={`tel:${call.whoCalled}`}
+              className="inline-flex items-center gap-1 text-slate-600 hover:text-slate-900"
+            >
+              <Phone className="h-3 w-3" /> Call
+            </a>
+          )}
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 pt-1">
+          {!mine ? (
+            <Button
+              onClick={onClaim}
+              disabled={busy}
+              className="h-12 text-base col-span-2 bg-blue-600 hover:bg-blue-700"
+            >
+              <Wrench className="h-4 w-4 mr-2" />
+              Claim this call
+            </Button>
+          ) : inProgress ? (
+            <Button
+              onClick={onComplete}
+              disabled={busy}
+              className="h-12 text-base col-span-2 bg-green-600 hover:bg-green-700"
+            >
+              <CheckCircle2 className="h-4 w-4 mr-2" />
+              Mark done
+            </Button>
+          ) : (
+            <>
+              <Button
+                onClick={onStart}
+                disabled={busy}
+                className="h-12 text-base bg-amber-600 hover:bg-amber-700"
+              >
+                <PlayCircle className="h-4 w-4 mr-2" />
+                Start
+              </Button>
+              <Button
+                onClick={onComplete}
+                disabled={busy}
+                variant="outline"
+                className="h-12 text-base"
+              >
+                <CheckCircle2 className="h-4 w-4 mr-2" />
+                Done
+              </Button>
+            </>
+          )}
+        </div>
+
+        <Link
+          href={`/dashboard/${call.id}/edit`}
+          className="block text-center text-xs text-slate-500 underline pt-1"
+        >
+          Open full details
+        </Link>
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const map: Record<string, { label: string; cls: string }> = {
+    OPEN: { label: "Open", cls: "bg-blue-100 text-blue-800" },
+    IN_PROGRESS: { label: "In Progress", cls: "bg-amber-100 text-amber-800" },
+    DONE: { label: "Done", cls: "bg-green-100 text-green-800" },
+  };
+  const s = map[status] || { label: status, cls: "bg-slate-100 text-slate-700" };
+  return (
+    <span
+      className={`shrink-0 rounded-full px-2.5 py-1 text-xs font-semibold ${s.cls}`}
+    >
+      {s.label}
+    </span>
+  );
+}

--- a/service-call-app/app/technician/page.tsx
+++ b/service-call-app/app/technician/page.tsx
@@ -1,0 +1,9 @@
+import TechnicianView from "./TechnicianView";
+
+export const metadata = {
+  title: "Technician — Service Calls",
+};
+
+export default function TechnicianPage() {
+  return <TechnicianView />;
+}

--- a/service-call-app/components/NavBar.tsx
+++ b/service-call-app/components/NavBar.tsx
@@ -29,6 +29,7 @@ import {
   Login as LoginIcon,
   Chat as ChatIcon,
   Description as DescriptionIcon,
+  Build as BuildIcon,
 } from "@mui/icons-material";
 import Image from "next/image";
 import Central from "@/public/central.jpg";
@@ -41,7 +42,13 @@ const Header = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
   useEffect(() => {
-    if (!loading && !user && pathname !== "/") {
+    if (
+      !loading &&
+      !user &&
+      pathname !== "/" &&
+      pathname !== "/technician" &&
+      pathname !== "/offline"
+    ) {
       router.push("/");
     }
   }, [loading, user, router, pathname]);
@@ -51,6 +58,7 @@ const Header = () => {
       { name: "Home", href: "/", icon: <HomeIcon /> },
       ...(user
         ? [
+            { name: "Technician", href: "/technician", icon: <BuildIcon /> },
             { name: "Dashboard", href: "/dashboard", icon: <DashboardIcon /> },
             { name: "Analytics", href: "/analytics", icon: <AnalyticsIcon /> },
           ]

--- a/service-call-app/components/PWARegister.tsx
+++ b/service-call-app/components/PWARegister.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Download, WifiOff, X } from "lucide-react";
+
+type BeforeInstallPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: "accepted" | "dismissed" }>;
+};
+
+const DISMISS_KEY = "pwa-install-dismissed-at";
+const DISMISS_WINDOW_MS = 1000 * 60 * 60 * 24 * 14;
+
+export default function PWARegister() {
+  const [installEvent, setInstallEvent] =
+    useState<BeforeInstallPromptEvent | null>(null);
+  const [showInstall, setShowInstall] = useState(false);
+  const [offline, setOffline] = useState(false);
+
+  useEffect(() => {
+    if (typeof navigator === "undefined") return;
+
+    if ("serviceWorker" in navigator) {
+      const onLoad = () => {
+        navigator.serviceWorker
+          .register("/sw.js", { scope: "/" })
+          .catch((err) => console.warn("SW registration failed:", err));
+      };
+      if (document.readyState === "complete") onLoad();
+      else window.addEventListener("load", onLoad, { once: true });
+    }
+
+    const onOnline = () => setOffline(false);
+    const onOffline = () => setOffline(true);
+    setOffline(!navigator.onLine);
+    window.addEventListener("online", onOnline);
+    window.addEventListener("offline", onOffline);
+
+    const onBeforeInstall = (e: Event) => {
+      e.preventDefault();
+      const dismissedAt = Number(localStorage.getItem(DISMISS_KEY) || 0);
+      if (Date.now() - dismissedAt < DISMISS_WINDOW_MS) return;
+      setInstallEvent(e as BeforeInstallPromptEvent);
+      setShowInstall(true);
+    };
+    window.addEventListener("beforeinstallprompt", onBeforeInstall);
+
+    const onInstalled = () => {
+      setInstallEvent(null);
+      setShowInstall(false);
+    };
+    window.addEventListener("appinstalled", onInstalled);
+
+    return () => {
+      window.removeEventListener("online", onOnline);
+      window.removeEventListener("offline", onOffline);
+      window.removeEventListener("beforeinstallprompt", onBeforeInstall);
+      window.removeEventListener("appinstalled", onInstalled);
+    };
+  }, []);
+
+  const handleInstall = async () => {
+    if (!installEvent) return;
+    await installEvent.prompt();
+    await installEvent.userChoice;
+    setInstallEvent(null);
+    setShowInstall(false);
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, String(Date.now()));
+    setShowInstall(false);
+  };
+
+  return (
+    <>
+      {offline && (
+        <div
+          role="status"
+          className="fixed top-16 inset-x-0 z-[1300] mx-auto max-w-md px-4"
+        >
+          <div className="flex items-center gap-2 rounded-full bg-amber-100 text-amber-900 border border-amber-300 px-4 py-2 shadow-md text-sm font-medium">
+            <WifiOff className="h-4 w-4" />
+            <span>Offline — changes will sync when you reconnect.</span>
+          </div>
+        </div>
+      )}
+
+      {showInstall && (
+        <div className="fixed bottom-4 inset-x-0 z-[1300] mx-auto max-w-md px-4">
+          <div className="flex items-center gap-3 rounded-xl bg-slate-900 text-white px-4 py-3 shadow-xl">
+            <Download className="h-5 w-5 shrink-0" />
+            <div className="flex-1 text-sm">
+              <div className="font-semibold">Install Service Call app</div>
+              <div className="text-slate-300 text-xs">
+                Adds a home-screen icon so you can work offline in the field.
+              </div>
+            </div>
+            <Button
+              size="sm"
+              onClick={handleInstall}
+              className="bg-white text-slate-900 hover:bg-slate-100"
+            >
+              Install
+            </Button>
+            <button
+              onClick={handleDismiss}
+              aria-label="Dismiss install prompt"
+              className="text-slate-400 hover:text-white"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/service-call-app/lib/firebase.ts
+++ b/service-call-app/lib/firebase.ts
@@ -1,6 +1,26 @@
-import { getFirestore } from "firebase/firestore";
+import {
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from "firebase/firestore";
 import { firebaseApp } from "./firebaseConfig";
 
-const db = getFirestore(firebaseApp);
+let db: Firestore;
+
+if (typeof window !== "undefined") {
+  try {
+    db = initializeFirestore(firebaseApp, {
+      localCache: persistentLocalCache({
+        tabManager: persistentMultipleTabManager(),
+      }),
+    });
+  } catch {
+    db = getFirestore(firebaseApp);
+  }
+} else {
+  db = getFirestore(firebaseApp);
+}
 
 export default db;

--- a/service-call-app/public/icons/icon-192.svg
+++ b/service-call-app/public/icons/icon-192.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#0f172a"/>
+  <g transform="translate(96 96)" stroke="#f8fafc" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M-36 36 L14 -14 a22 22 0 1 0 -8 -8 L-44 28 a6 6 0 0 0 0 8 l6 6 a6 6 0 0 0 8 0 z"/>
+    <circle cx="22" cy="-22" r="6" fill="#f8fafc"/>
+  </g>
+  <text x="96" y="172" font-family="Helvetica, Arial, sans-serif" font-size="22" font-weight="700" fill="#f8fafc" text-anchor="middle">SERVICE</text>
+</svg>

--- a/service-call-app/public/icons/icon-512.svg
+++ b/service-call-app/public/icons/icon-512.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="96" fill="#0f172a"/>
+  <g transform="translate(256 256)" stroke="#f8fafc" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M-96 96 L36 -36 a56 56 0 1 0 -22 -22 L-116 72 a16 16 0 0 0 0 22 l16 18 a16 16 0 0 0 22 0 z"/>
+    <circle cx="58" cy="-58" r="16" fill="#f8fafc"/>
+  </g>
+  <text x="256" y="460" font-family="Helvetica, Arial, sans-serif" font-size="56" font-weight="700" fill="#f8fafc" text-anchor="middle">SERVICE</text>
+</svg>

--- a/service-call-app/public/icons/icon-maskable.svg
+++ b/service-call-app/public/icons/icon-maskable.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" fill="#0f172a"/>
+  <g transform="translate(256 256)" stroke="#f8fafc" stroke-width="24" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M-70 70 L28 -28 a44 44 0 1 0 -18 -18 L-86 54 a14 14 0 0 0 0 18 l14 14 a14 14 0 0 0 18 0 z"/>
+    <circle cx="46" cy="-46" r="12" fill="#f8fafc"/>
+  </g>
+</svg>

--- a/service-call-app/public/manifest.json
+++ b/service-call-app/public/manifest.json
@@ -1,0 +1,48 @@
+{
+  "name": "Service Call Dashboard",
+  "short_name": "Service Calls",
+  "description": "Create, assign, and update service calls from the field. Works offline.",
+  "start_url": "/technician",
+  "scope": "/",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#ffffff",
+  "theme_color": "#000000",
+  "categories": ["business", "productivity", "utilities"],
+  "icons": [
+    {
+      "src": "/icons/icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/icons/icon-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ],
+  "shortcuts": [
+    {
+      "name": "My Open Calls",
+      "short_name": "My Calls",
+      "description": "Jump to service calls assigned to me",
+      "url": "/technician",
+      "icons": [{ "src": "/icons/icon-192.svg", "sizes": "192x192" }]
+    },
+    {
+      "name": "New Service Call",
+      "short_name": "New Call",
+      "description": "Create a new service call",
+      "url": "/dashboard/create",
+      "icons": [{ "src": "/icons/icon-192.svg", "sizes": "192x192" }]
+    }
+  ]
+}

--- a/service-call-app/public/sw.js
+++ b/service-call-app/public/sw.js
@@ -1,0 +1,132 @@
+/*
+ * Service Call Dashboard — service worker
+ *
+ * Strategy:
+ *   - Precache a minimal app shell (offline fallback page + manifest/icons).
+ *   - Cache-first for static Next.js build assets (/_next/static/*, /icons/*).
+ *   - Network-first with cached fallback for same-origin navigations.
+ *   - Never intercept Firestore / Firebase Auth / Google APIs — Firestore handles
+ *     its own offline persistence and intercepting its traffic would break syncing.
+ */
+
+const VERSION = "scd-pwa-v1";
+const SHELL_CACHE = `${VERSION}-shell`;
+const STATIC_CACHE = `${VERSION}-static`;
+const PAGES_CACHE = `${VERSION}-pages`;
+
+const OFFLINE_URL = "/offline";
+const SHELL_URLS = [
+  OFFLINE_URL,
+  "/manifest.json",
+  "/icons/icon-192.svg",
+  "/icons/icon-512.svg",
+  "/icons/icon-maskable.svg",
+];
+
+const NEVER_CACHE_HOSTS = [
+  "firestore.googleapis.com",
+  "firebaseinstallations.googleapis.com",
+  "identitytoolkit.googleapis.com",
+  "securetoken.googleapis.com",
+  "www.googleapis.com",
+  "apis.google.com",
+  "firebase.googleapis.com",
+  "fcm.googleapis.com",
+];
+
+self.addEventListener("install", (event) => {
+  event.waitUntil(
+    (async () => {
+      const cache = await caches.open(SHELL_CACHE);
+      await cache.addAll(SHELL_URLS).catch(() => {});
+      self.skipWaiting();
+    })()
+  );
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    (async () => {
+      const keys = await caches.keys();
+      await Promise.all(
+        keys
+          .filter((key) => !key.startsWith(VERSION))
+          .map((key) => caches.delete(key))
+      );
+      await self.clients.claim();
+    })()
+  );
+});
+
+self.addEventListener("message", (event) => {
+  if (event.data === "SKIP_WAITING") self.skipWaiting();
+});
+
+function isStaticAsset(url) {
+  return (
+    url.pathname.startsWith("/_next/static/") ||
+    url.pathname.startsWith("/icons/") ||
+    url.pathname === "/manifest.json" ||
+    /\.(?:css|js|woff2?|ttf|png|jpe?g|gif|svg|webp|ico)$/.test(url.pathname)
+  );
+}
+
+async function networkFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  try {
+    const fresh = await fetch(request);
+    if (fresh && fresh.ok && request.method === "GET") {
+      cache.put(request, fresh.clone());
+    }
+    return fresh;
+  } catch (err) {
+    const cached = await cache.match(request);
+    if (cached) return cached;
+    throw err;
+  }
+}
+
+async function cacheFirst(request, cacheName) {
+  const cache = await caches.open(cacheName);
+  const cached = await cache.match(request);
+  if (cached) return cached;
+  const fresh = await fetch(request);
+  if (fresh && fresh.ok) cache.put(request, fresh.clone());
+  return fresh;
+}
+
+self.addEventListener("fetch", (event) => {
+  const request = event.request;
+  if (request.method !== "GET") return;
+
+  const url = new URL(request.url);
+
+  if (NEVER_CACHE_HOSTS.some((host) => url.hostname.endsWith(host))) return;
+  if (url.origin !== self.location.origin) return;
+  if (url.pathname.startsWith("/api/")) return;
+
+  if (request.mode === "navigate") {
+    event.respondWith(
+      (async () => {
+        try {
+          return await networkFirst(request, PAGES_CACHE);
+        } catch {
+          const cache = await caches.open(SHELL_CACHE);
+          const offline = await cache.match(OFFLINE_URL);
+          return (
+            offline ||
+            new Response("You are offline.", {
+              status: 503,
+              headers: { "Content-Type": "text/plain" },
+            })
+          );
+        }
+      })()
+    );
+    return;
+  }
+
+  if (isStaticAsset(url)) {
+    event.respondWith(cacheFirst(request, STATIC_CACHE).catch(() => fetch(request)));
+  }
+});


### PR DESCRIPTION
Turn the dashboard into an installable PWA targeted at field technicians.
Adds a mobile-first /technician view where techs can see their open calls,
claim unassigned calls, and advance status (Open -> In Progress -> Done)
with one tap. Firestore IndexedDB persistence plus a service worker let
the app load and queue status updates while offline; updates sync when
connectivity returns.

Includes manifest + icons, install prompt, offline banner, offline
fallback page, and a usage guide in PWA_GUIDE.md.

https://claude.ai/code/session_01C1TYER3bWUXZDhHjPodmJ1