### PR TITLE
feat(pwa): polish mobile UX to feel more native

### DIFF
--- a/service-call-app/app/globals.css
+++ b/service-call-app/app/globals.css
@@ -63,7 +63,78 @@
   * {
     @apply border-border;
   }
+
+  html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+    overscroll-behavior-y: none;
+  }
+
   body {
     @apply bg-background text-foreground;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    overscroll-behavior-y: none;
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
   }
+
+  /* Stop long-press callout/selection on UI chrome, keep it for readable content */
+  button,
+  a,
+  [role="button"],
+  [role="tab"],
+  [role="menuitem"] {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+
+  /* Re-enable selection for text content */
+  p,
+  span,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  li,
+  td,
+  input,
+  textarea,
+  [contenteditable="true"] {
+    -webkit-user-select: auto;
+    user-select: auto;
+  }
+
+  /* Lock input font-size to 16px on mobile so iOS doesn't zoom the viewport on focus */
+  @media (max-width: 640px) {
+    input:not([type="checkbox"]):not([type="radio"]):not([type="range"]),
+    select,
+    textarea {
+      font-size: 16px;
+    }
+  }
+}
+
+/* When launched as an installed PWA, act more like a native app */
+html[data-standalone="true"] body {
+  /* Kill rubber-band/pull-to-refresh inside the app shell */
+  overscroll-behavior: none;
+}
+
+html[data-standalone="true"],
+html[data-standalone="true"] body {
+  user-select: none;
+  -webkit-user-select: none;
+}
+
+html[data-standalone="true"] input,
+html[data-standalone="true"] textarea,
+html[data-standalone="true"] [contenteditable="true"] {
+  user-select: auto;
+  -webkit-user-select: auto;
 }

--- a/service-call-app/app/layout.tsx
+++ b/service-call-app/app/layout.tsx
@@ -24,13 +24,23 @@ export const metadata: Metadata = {
     statusBarStyle: "black-translucent",
     title: "Service Calls",
   },
+  formatDetection: {
+    telephone: false,
+    email: false,
+    address: false,
+  },
+  other: {
+    "mobile-web-app-capable": "yes",
+  },
 };
 
 export const viewport: Viewport = {
   themeColor: "#000000",
   width: "device-width",
   initialScale: 1,
+  maximumScale: 1,
   viewportFit: "cover",
+  userScalable: false,
 };
 
 export default function RootLayout({

--- a/service-call-app/components/ChatBot.tsx
+++ b/service-call-app/components/ChatBot.tsx
@@ -91,15 +91,17 @@ export default function ChatWithDatabase({ children }: ChatProps) {
         onClick={handleOpen}
         sx={{
           position: "fixed",
-          bottom: 24,
-          right: 24,
+          bottom: "calc(24px + env(safe-area-inset-bottom))",
+          right: "calc(24px + env(safe-area-inset-right))",
           zIndex: 1300,
           padding: "16px",
           boxShadow: "0px 4px 12px rgba(0, 0, 0, 0.1)",
+          transition: "transform 120ms ease-out",
+          "&:active": { transform: "scale(0.96)" },
           "@media (max-width:600px)": {
-            bottom: 16,
-            right: 16,
-          }, // Adjust button position on small screens
+            bottom: "calc(88px + env(safe-area-inset-bottom))",
+            right: "calc(16px + env(safe-area-inset-right))",
+          }, // Lift above the technician FAB and home indicator
         }}
       >
         Open Chat
@@ -122,6 +124,7 @@ export default function ChatWithDatabase({ children }: ChatProps) {
             boxShadow: "0px -4px 12px rgba(0, 0, 0, 0.1)",
             transition: "transform 0.3s ease-out",
             margin: "10px",
+            paddingBottom: "env(safe-area-inset-bottom)",
           },
         }}
         sx={{

--- a/service-call-app/components/PWARegister.tsx
+++ b/service-call-app/components/PWARegister.tsx
@@ -19,6 +19,18 @@ export default function PWARegister() {
       else window.addEventListener("load", onLoad, { once: true });
     }
 
+    const standaloneMQ = window.matchMedia("(display-mode: standalone)");
+    const applyStandalone = () => {
+      const isStandalone =
+        standaloneMQ.matches ||
+        (navigator as Navigator & { standalone?: boolean }).standalone === true;
+      document.documentElement.dataset.standalone = isStandalone
+        ? "true"
+        : "false";
+    };
+    applyStandalone();
+    standaloneMQ.addEventListener?.("change", applyStandalone);
+
     const onOnline = () => setOffline(false);
     const onOffline = () => setOffline(true);
     setOffline(!navigator.onLine);
@@ -26,6 +38,7 @@ export default function PWARegister() {
     window.addEventListener("offline", onOffline);
 
     return () => {
+      standaloneMQ.removeEventListener?.("change", applyStandalone);
       window.removeEventListener("online", onOnline);
       window.removeEventListener("offline", onOffline);
     };


### PR DESCRIPTION
- Disable iOS zoom on input focus by locking form font-size to 16px on
  small screens, and prevent accidental viewport zoom via maximumScale/
  userScalable.
- Remove tap-highlight flash and long-press callouts on UI chrome while
  preserving text selection in readable content and form fields.
- Stop body overscroll/rubber-band and pull-to-refresh when launched as
  an installed PWA (gated on data-standalone) so the shell behaves like
  a native app instead of a scrolling web page.
- Add format-detection and mobile-web-app-capable meta for Android/
  cross-browser parity with the existing Apple PWA tags.
- Lift the ChatBot FAB above the technician FAB and the iOS home
  indicator via env(safe-area-inset-*) and add an active-scale tap
  affordance; respect safe-area-inset-bottom inside the chat sheet.
- Detect display-mode: standalone in PWARegister and expose it as
  html[data-standalone] so standalone-only rules don't affect the in-
  browser experience.