### PR TITLE
fix(pwa): unify --bottom-nav-h and add mobile card view for dashboard

### DIFF
--- a/service-call-app/app/admin/AdminView.tsx
+++ b/service-call-app/app/admin/AdminView.tsx
@@ -187,8 +187,7 @@ export default function AdminView() {
     <main
       className="max-w-5xl mx-auto px-3 sm:px-6 pt-4 space-y-5"
       style={{
-        paddingBottom:
-          "calc(3rem + var(--bottom-nav-h) + env(safe-area-inset-bottom))",
+        paddingBottom: "calc(3rem + var(--bottom-nav-h))",
       }}
     >
       <header className="flex items-center justify-between gap-2">

--- a/service-call-app/app/analytics/page.tsx
+++ b/service-call-app/app/analytics/page.tsx
@@ -288,8 +288,7 @@ export default function AnalyticsPage() {
     <div
       className="min-h-screen bg-gradient-to-br from-gray-50 to-gray-100 p-4 lg:p-6"
       style={{
-        paddingBottom:
-          "calc(1.5rem + var(--bottom-nav-h) + env(safe-area-inset-bottom))",
+        paddingBottom: "calc(1.5rem + var(--bottom-nav-h))",
       }}
     >
       <div className="max-w-7xl mx-auto space-y-6">

--- a/service-call-app/app/dashboard/page.tsx
+++ b/service-call-app/app/dashboard/page.tsx
@@ -44,10 +44,7 @@ export default async function DashboardPage() {
   return (
     <div
       className="flex flex-col min-h-screen bg-gray-100"
-      style={{
-        paddingBottom:
-          "calc(var(--bottom-nav-h) + env(safe-area-inset-bottom))",
-      }}
+      style={{ paddingBottom: "var(--bottom-nav-h)" }}
     >
       {/* Main Content */}
       <main className="flex-1">

--- a/service-call-app/app/globals.css
+++ b/service-call-app/app/globals.css
@@ -142,9 +142,15 @@ html[data-standalone="true"] [contenteditable="true"] {
 }
 
 /* Reserve space at the bottom of every scroll container for the mobile
- * tab bar. Only active on narrow viewports where the tab bar is visible. */
+ * tab bar. Only active on narrow viewports where the tab bar is visible.
+ * Includes safe-area so pages can use --bottom-nav-h as the single source
+ * of truth and should NOT add env(safe-area-inset-bottom) again. */
 @media (max-width: 767px) {
   html[data-bottom-nav="true"] {
-    --bottom-nav-h: 3.75rem;
+    --bottom-nav-h: calc(3.25rem + env(safe-area-inset-bottom));
   }
+}
+
+html[data-bottom-nav="true"] {
+  scroll-padding-bottom: var(--bottom-nav-h);
 }

--- a/service-call-app/app/page.tsx
+++ b/service-call-app/app/page.tsx
@@ -10,8 +10,7 @@ export default function Home() {
         paddingTop: "0.5rem",
         paddingLeft: "0.5rem",
         paddingRight: "0.5rem",
-        paddingBottom:
-          "calc(0.5rem + var(--bottom-nav-h) + env(safe-area-inset-bottom))",
+        paddingBottom: "calc(0.5rem + var(--bottom-nav-h))",
         backgroundColor: "#f4f6f9",
         width: "100%",
         maxWidth: "2000px",

--- a/service-call-app/app/technician/TechnicianView.tsx
+++ b/service-call-app/app/technician/TechnicianView.tsx
@@ -234,8 +234,7 @@ export default function TechnicianView() {
     <main
       className="px-3 pt-3 max-w-2xl mx-auto"
       style={{
-        paddingBottom:
-          "calc(4.5rem + var(--bottom-nav-h) + env(safe-area-inset-bottom))",
+        paddingBottom: "calc(5rem + var(--bottom-nav-h))",
       }}
     >
       <header className="flex items-center justify-between gap-2 mb-3">
@@ -352,8 +351,7 @@ export default function TechnicianView() {
         className="fixed z-40 flex items-center gap-2 rounded-full bg-slate-900 text-white px-5 py-3 shadow-xl active:scale-95 transition"
         style={{
           right: "calc(1.25rem + env(safe-area-inset-right))",
-          bottom:
-            "calc(1rem + var(--bottom-nav-h) + env(safe-area-inset-bottom))",
+          bottom: "calc(0.75rem + var(--bottom-nav-h))",
         }}
       >
         <Plus className="h-5 w-5" />

--- a/service-call-app/app/testing/columns.tsx
+++ b/service-call-app/app/testing/columns.tsx
@@ -1,36 +1,12 @@
 "use client";
 
 import { ColumnDef } from "@tanstack/react-table";
-import { MoreHorizontal } from "lucide-react";
-
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { DataTableColumnHeader } from "@/components/DataColumnHeader";
-
-import Link from "next/link";
 
 import Status from "../../components/Status";
 import { ServiceCall } from "../(definitions)/definitions";
 import TakenBy from "@/components/TakenBy";
-import { useAuth } from "@/components/AuthContext";
-import { deleteServiceCall } from "../dashboard/action";
-import { useRef, useState } from "react";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTrigger,
-} from "@/components/ui/alert-dialog";
+import ServiceCallRowActions from "@/components/ServiceCallRowActions";
 
 export const columns: ColumnDef<ServiceCall>[] = [
   {
@@ -114,88 +90,6 @@ export const columns: ColumnDef<ServiceCall>[] = [
   },
   {
     id: "actions",
-    cell: ({ row }) => {
-      const serviceCall = row.original;
-      const { user } = useAuth();
-      const allowedUsers = ["Joe Hinderer", "Eric Hinderer"];
-      const canDelete = allowedUsers.includes(user?.displayName ?? "");
-      const [isDialogOpen, setIsDialogOpen] = useState(false);
-      const dropdownTriggerRef = useRef<HTMLButtonElement>(null);
-
-      const handleDelete = async () => {
-        try {
-          const response = await deleteServiceCall(serviceCall.id);
-          if (response.success) {
-            console.log("Service call deleted successfully");
-          } else {
-            console.error("Failed to delete service call:", response.message);
-          }
-        } catch (error) {
-          console.error("Error during deletion:", error);
-        }
-      };
-      return (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="sm" ref={dropdownTriggerRef}>
-              <MoreHorizontal />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
-            <Link href={`/dashboard/${serviceCall.id}/edit`}>
-              <DropdownMenuItem>Edit</DropdownMenuItem>
-            </Link>
-            <DropdownMenuSeparator />
-            {canDelete && (
-              <>
-                <DropdownMenuItem
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    setIsDialogOpen(true); 
-                    dropdownTriggerRef.current?.blur() 
-                  }}
-                >
-                  Delete
-                </DropdownMenuItem>
-
-                {/* Alert Dialog for Deleting Confirmation */}
-                <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
-                  <AlertDialogTrigger asChild>
-                    <span />
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      Are you sure you want to delete this service call?
-                    </AlertDialogHeader>
-                    <div>
-                      <p>This action cannot be undone.</p>
-                      <p>
-                        You are about to delete the service call for the
-                        machine: <strong>{serviceCall.machine}</strong> at{" "}
-                        <strong>{serviceCall.location}</strong>.
-                      </p>
-                    </div>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel onClick={() => setIsDialogOpen(false)}>
-                        Cancel
-                      </AlertDialogCancel>
-                      <AlertDialogAction
-                        onClick={() => {
-                          handleDelete();
-                          setIsDialogOpen(false);
-                        }}
-                      >
-                        Confirm Delete
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
-              </>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      );
-    },
+    cell: ({ row }) => <ServiceCallRowActions serviceCall={row.original} />,
   },
 ];

--- a/service-call-app/app/testing/data-table.tsx
+++ b/service-call-app/app/testing/data-table.tsx
@@ -12,14 +12,7 @@ import {
   getFilteredRowModel,
 } from "@tanstack/react-table";
 import { AiOutlineClose } from "react-icons/ai";
-import {
-  Typography,
-  Container,
-  Box,
-  useMediaQuery,
-  IconButton,
-  TextField,
-} from "@mui/material";
+import { Box, IconButton, TextField } from "@mui/material";
 
 import Grid from "@mui/material/Grid2";
 import {
@@ -38,6 +31,11 @@ import db from "@/lib/firebase";
 import { ServiceCall } from "../(definitions)/definitions";
 import ExcelJS from "exceljs";
 import { Button } from "@/components/ui/button";
+import Status from "@/components/Status";
+import TakenBy from "@/components/TakenBy";
+import ServiceCallRowActions from "@/components/ServiceCallRowActions";
+import { formatDistanceToNow } from "date-fns";
+import { AlertCircle, Clock, MapPin } from "lucide-react";
 
 interface DataTableProps {
   columns: ColumnDef<ServiceCall, any>[];
@@ -47,7 +45,6 @@ export function DataTable({ columns }: DataTableProps) {
   const [serviceCalls, setServiceCalls] = useState<ServiceCall[]>([]);
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
-  const isMobile = useMediaQuery("(max-width:600px)");
 
   useEffect(() => {
     const q = query(collection(db, "ServiceCalls"), orderBy("date", "desc"));
@@ -129,14 +126,14 @@ export function DataTable({ columns }: DataTableProps) {
 
   return (
     <div>
-      <Box sx={{ padding: 2 }}>
+      <Box sx={{ padding: { xs: 0, sm: 2 }, pb: { xs: 2, sm: 2 } }}>
         <Box
           sx={{
             display: "flex",
-            justifyContent: { xs: "center", md: "flex-end" },
+            justifyContent: { xs: "stretch", md: "flex-end" },
             alignItems: "center",
             flexDirection: { xs: "column", sm: "row" },
-            pb: 4,
+            pb: { xs: 2, sm: 4 },
             gap: 2,
           }}
         >
@@ -156,7 +153,7 @@ export function DataTable({ columns }: DataTableProps) {
         </Box>
 
         <Grid container spacing={2}>
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 6, sm: 6, md: 3 }}>
             <TextField
               label="Search Location"
               value={
@@ -186,7 +183,7 @@ export function DataTable({ columns }: DataTableProps) {
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 6, sm: 6, md: 3 }}>
             <TextField
               label="Search Machine"
               value={
@@ -216,7 +213,7 @@ export function DataTable({ columns }: DataTableProps) {
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 6, sm: 6, md: 3 }}>
             <TextField
               label="Search Problem"
               value={
@@ -250,7 +247,7 @@ export function DataTable({ columns }: DataTableProps) {
             />
           </Grid>
 
-          <Grid size={{ xs: 12, sm: 6, md: 3 }}>
+          <Grid size={{ xs: 6, sm: 6, md: 3 }}>
             <TextField
               label="Search Notes"
               value={
@@ -281,7 +278,7 @@ export function DataTable({ columns }: DataTableProps) {
           </Grid>
         </Grid>
       </Box>
-      <div className="rounded-md border">
+      <div className="hidden md:block rounded-md border">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
@@ -331,6 +328,96 @@ export function DataTable({ columns }: DataTableProps) {
           </TableBody>
         </Table>
         <DataTablePagination table={table} />
+      </div>
+
+      {/* Mobile card list */}
+      <div className="md:hidden">
+        {table.getRowModel().rows?.length ? (
+          <ul className="space-y-2">
+            {table.getRowModel().rows.map((row) => {
+              const call = row.original;
+              return (
+                <li
+                  key={row.id}
+                  className="rounded-lg border border-slate-200 bg-white p-3 shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0">
+                      <div className="flex items-center gap-1.5 font-semibold text-slate-900 truncate">
+                        <MapPin
+                          className="h-4 w-4 text-slate-500 shrink-0"
+                          aria-hidden
+                        />
+                        <span className="truncate">
+                          {call.location || "Unknown"}
+                        </span>
+                      </div>
+                      <div className="flex items-center gap-1.5 text-xs text-slate-500 mt-0.5">
+                        <Clock className="h-3 w-3" aria-hidden />
+                        {call.date
+                          ? formatDistanceToNow(call.date, { addSuffix: true })
+                          : "No date"}
+                        {call.overDue && (
+                          <span className="ml-1 inline-flex items-center gap-0.5 text-red-700 font-medium">
+                            <AlertCircle className="h-3 w-3" aria-hidden />
+                            Overdue
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    <ServiceCallRowActions serviceCall={call} />
+                  </div>
+
+                  <div className="text-sm text-slate-800 mt-2">
+                    <span className="font-medium text-slate-700">Problem:</span>{" "}
+                    {call.reportedProblem || "—"}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-1 text-xs text-slate-600 mt-2">
+                    <div className="truncate">
+                      <span className="font-medium text-slate-700">
+                        Machine:
+                      </span>{" "}
+                      {call.machine || "—"}
+                    </div>
+                    <div className="truncate">
+                      <span className="font-medium text-slate-700">
+                        Caller:
+                      </span>{" "}
+                      {call.whoCalled || "—"}
+                    </div>
+                  </div>
+
+                  {call.notes && (
+                    <div className="text-xs bg-slate-50 rounded-md p-2 text-slate-700 border border-slate-100 mt-2">
+                      {call.notes}
+                    </div>
+                  )}
+
+                  <div className="flex items-center justify-between gap-2 mt-3 pt-2 border-t border-slate-100">
+                    <div className="min-w-0">
+                      <TakenBy
+                        id={call.id.toString()}
+                        currentTakenBy={call.takenBy!}
+                      />
+                    </div>
+                    <Status
+                      id={call.id.toString()}
+                      currentStatus={call.status}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          <div className="rounded-lg border border-dashed border-slate-200 bg-white p-6 text-center text-sm text-slate-500">
+            No results.
+          </div>
+        )}
+        <div className="mt-3">
+          <DataTablePagination table={table} />
+        </div>
       </div>
     </div>
   );

--- a/service-call-app/components/PaginationTable.tsx
+++ b/service-call-app/components/PaginationTable.tsx
@@ -24,14 +24,14 @@ export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
   return (
-    <div className="flex items-center justify-between px-2">
-      <div className="flex-1 text-sm text-muted-foreground">
+    <div className="flex flex-wrap items-center justify-between gap-3 px-2 py-2">
+      <div className="hidden sm:block flex-1 text-sm text-muted-foreground">
         {table.getFilteredSelectedRowModel().rows.length} of{" "}
         {table.getFilteredRowModel().rows.length} row(s) selected.
       </div>
-      <div className="flex items-center space-x-6 lg:space-x-8">
+      <div className="flex flex-wrap items-center gap-3 sm:gap-6 lg:gap-8">
         <div className="flex items-center space-x-2">
-          <p className="text-sm font-medium">Rows per page</p>
+          <p className="text-sm font-medium whitespace-nowrap">Rows per page</p>
           <Select
             value={`${table.getState().pagination.pageSize}`}
             onValueChange={(value) => {
@@ -50,7 +50,7 @@ export function DataTablePagination<TData>({
             </SelectContent>
           </Select>
         </div>
-        <div className="flex w-[100px] items-center justify-center text-sm font-medium">
+        <div className="flex items-center justify-center text-sm font-medium whitespace-nowrap">
           Page {table.getState().pagination.pageIndex + 1} of{" "}
           {table.getPageCount()}
         </div>

--- a/service-call-app/components/ServiceCallRowActions.tsx
+++ b/service-call-app/components/ServiceCallRowActions.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import Link from "next/link";
+import { useRef, useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { useAuth } from "@/components/AuthContext";
+import { deleteServiceCall } from "@/app/dashboard/action";
+import { ServiceCall } from "@/app/(definitions)/definitions";
+
+const DELETE_ALLOWED_USERS = ["Joe Hinderer", "Eric Hinderer"];
+
+export default function ServiceCallRowActions({
+  serviceCall,
+}: {
+  serviceCall: ServiceCall;
+}) {
+  const { user } = useAuth();
+  const canDelete = DELETE_ALLOWED_USERS.includes(user?.displayName ?? "");
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const dropdownTriggerRef = useRef<HTMLButtonElement>(null);
+
+  const handleDelete = async () => {
+    try {
+      const response = await deleteServiceCall(serviceCall.id);
+      if (!response.success) {
+        console.error("Failed to delete service call:", response.message);
+      }
+    } catch (error) {
+      console.error("Error during deletion:", error);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="sm"
+          ref={dropdownTriggerRef}
+          aria-label="Row actions"
+          className="h-9 w-9 p-0"
+        >
+          <MoreHorizontal className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <Link href={`/dashboard/${serviceCall.id}/edit`}>
+          <DropdownMenuItem>Edit</DropdownMenuItem>
+        </Link>
+        {canDelete && (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setIsDialogOpen(true);
+                dropdownTriggerRef.current?.blur();
+              }}
+            >
+              Delete
+            </DropdownMenuItem>
+
+            <AlertDialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+              <AlertDialogTrigger asChild>
+                <span />
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  Are you sure you want to delete this service call?
+                </AlertDialogHeader>
+                <div>
+                  <p>This action cannot be undone.</p>
+                  <p>
+                    You are about to delete the service call for the machine:{" "}
+                    <strong>{serviceCall.machine}</strong> at{" "}
+                    <strong>{serviceCall.location}</strong>.
+                  </p>
+                </div>
+                <AlertDialogFooter>
+                  <AlertDialogCancel onClick={() => setIsDialogOpen(false)}>
+                    Cancel
+                  </AlertDialogCancel>
+                  <AlertDialogAction
+                    onClick={() => {
+                      handleDelete();
+                      setIsDialogOpen(false);
+                    }}
+                  >
+                    Confirm Delete
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}


### PR DESCRIPTION
The tech page bottom bar was misaligned on iPhones because every page added
env(safe-area-inset-bottom) on top of --bottom-nav-h, while the tab bar
itself already reserved safe-area via its own padding — so the inset was
counted twice, producing a large gap above the nav and a floating FAB.

- Make --bottom-nav-h include safe-area: single source of truth; pages no
  longer add env(safe-area-inset-bottom) separately (home, dashboard,
  technician, admin, analytics).
- Shrink technician page padding-bottom and FAB offset to match.
- Add scroll-padding-bottom on html when the nav is visible.

Dashboard (/dashboard) rendered a 7-column <table> with no mobile fallback.
Add a mobile card list under md and hide the table; extract the row
actions dropdown into ServiceCallRowActions for reuse. Tighten the filter
bar on mobile (2-per-row) and let PaginationTable wrap.